### PR TITLE
Fix for supporting nested variable declarations

### DIFF
--- a/src/definitions/index.js
+++ b/src/definitions/index.js
@@ -73,9 +73,10 @@ export function assertEach(callback: Function): Function {
   return validator;
 }
 
-export function assertOneOf(...vals: Array<string>): Function {
+export function assertOneOf(vals: Array<string>): Function {
   function validate(node, key, val) {
-    if (vals.indexOf(val) < 0) {
+      const valid = vals.some(type => t.is(type, val));
+      if (!valid) {
       throw new TypeError(
         `Property ${key} expected value to be one of ${JSON.stringify(
           vals


### PR DESCRIPTION
Code like the following was failing: 

```js
const ast = t.document([
        t.operationDefinition(
            "mutation",
            t.selectionSet([
              t.field(t.name('foo')),
              t.field(t.name('bar'))
            ]),
            t.name("CreateUser"),
            [
                t.variableDefinition(t.variable(t.name("moo")), t.nonNullType(t.namedType(t.name("User"))) )
            ]
        )
    ]);
```